### PR TITLE
fixing issue with child process not closing the folders items

### DIFF
--- a/lib/report_portal/cucumber/report.rb
+++ b/lib/report_portal/cucumber/report.rb
@@ -173,16 +173,14 @@ module ReportPortal
       def test_run_finished(_event, desired_time)
         end_feature(desired_time) unless @parent_item_node.is_root?
         @logger.info("Test run finish,")
+        close_all_children_of(@root_node) # Folder items are closed here as they can't be closed after finishing a feature
         if parallel
           if ParallelTests.first_process?
             ParallelTests.wait_for_other_processes_to_finish
-            close_all_children_of(@root_node) # Folder items are closed here as they can't be closed after finishing a feature
             File.delete(lock_file)
             @logger.info("close launch , delete lock")
             complete_launch(desired_time)
           end
-        else
-          close_all_children_of(@root_node) # Folder items are closed here as they can't be closed after finishing a feature
         end
       end
 

--- a/lib/reportportal.rb
+++ b/lib/reportportal.rb
@@ -155,15 +155,18 @@ module ReportPortal
         response = JSON.parse(e.response)
         m = response['message'].match(%r{Start time of child \['(.+)'\] item should be same or later than start time \['(.+)'\] of the parent item\/launch '.+'})
         if m
-          time = Time.strptime(m[2], '%a %b %d %H:%M:%S %z %Y')
-          data[:start_time] = (time.to_f * 1000).to_i + 1000
-          ReportPortal.last_used_time = data[:start_time]
+          parent_time = Time.strptime(m[2], '%a %b %d %H:%M:%S %z %Y')
+          data = JSON.parse(options[0])
+          self.logger.warn("RP error : 40025, time of a child: [#{data['start_time']}], paren time: [#{(parent_time.to_f * 1000).to_i}]")
+          data['start_time'] = (parent_time.to_f * 1000).to_i + 1000
+          options[0] = data.to_json
+          ReportPortal.last_used_time = time
         else
           self.logger.error("RestClient::Exception -> response: [#{response}]")
           self.logger.error("TRACE[#{e.backtrace}]")
           raise
         end
-        
+
         retry unless (tries -= 1).zero?
       end
       JSON.parse(response)


### PR DESCRIPTION
removing parallel formatter, single formatter should be the only option. As parallel_cucumber simply runs cucumber as a sub process 